### PR TITLE
[LB-9] 회원탈퇴

### DIFF
--- a/src/main/java/com/lgcms/auth/api/open/AuthController.java
+++ b/src/main/java/com/lgcms/auth/api/open/AuthController.java
@@ -9,10 +9,7 @@ import com.lgcms.auth.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RequestMapping("/open/auth/")
@@ -35,5 +32,10 @@ public class AuthController {
     @PostMapping("/refresh/token")
     public ResponseEntity<TokenResponse> refreshToken(@RequestBody RefreshTokenRequest request) {
         return ResponseEntity.ok(authService.refreshToken(request.refreshToken()));
+    }
+
+    @DeleteMapping("/logout")
+    public ResponseEntity<Boolean> logout(@RequestHeader("X-JTI") String jti) {
+        return ResponseEntity.ok(authService.logout(jti));
     }
 }

--- a/src/main/java/com/lgcms/auth/api/open/AuthController.java
+++ b/src/main/java/com/lgcms/auth/api/open/AuthController.java
@@ -38,4 +38,12 @@ public class AuthController {
     public ResponseEntity<Boolean> logout(@RequestHeader("X-JTI") String jti) {
         return ResponseEntity.ok(authService.logout(jti));
     }
+
+    @PostMapping("/sign-out/google")
+    public ResponseEntity<Boolean> signout(
+        @RequestHeader("X-JTI") String jti,
+        @RequestHeader("X-USER-ID") Long memberId
+    ) {
+        return ResponseEntity.ok(authService.signout(jti, memberId));
+    }
 }

--- a/src/main/java/com/lgcms/auth/common/dto/exception/AuthError.java
+++ b/src/main/java/com/lgcms/auth/common/dto/exception/AuthError.java
@@ -15,6 +15,7 @@ public enum AuthError implements ErrorCodeInterface {
     NO_SUCH_SOCIAL_TYPE("AUTH_006", "지원하는 소셜 로그인 타입이 아닙니다.", HttpStatus.NOT_FOUND),
     FAILED_GOOGLE_SOCIAL_LOGIN("AUTH_007", "구글 소셜 로그인에 실패했습니다.", HttpStatus.BAD_REQUEST),
     MEMBER_SERVER_ERROR("AUTH_008", "회원 서버 통신 오류", HttpStatus.I_AM_A_TEAPOT),
+    USED_REFRESH_TOKEN("AUTH_009", "사용할 수 없는 리프레시 토큰입니다.", HttpStatus.BAD_REQUEST),
     ;
     private final String status;
     private final String message;

--- a/src/main/java/com/lgcms/auth/config/RedisConfig.java
+++ b/src/main/java/com/lgcms/auth/config/RedisConfig.java
@@ -1,0 +1,36 @@
+package com.lgcms.auth.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    @Value("${spring.data.redis.host}")
+    private String host;
+    @Value("${spring.data.redis.port}")
+    private int port;
+    @Value("${spring.data.redis.database}")
+    private int database;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(host, port);
+        connectionFactory.setDatabase(database);
+        return connectionFactory;
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/lgcms/auth/remote/member/RemoteMemberService.java
+++ b/src/main/java/com/lgcms/auth/remote/member/RemoteMemberService.java
@@ -4,8 +4,10 @@ import com.lgcms.auth.remote.member.dto.MemberRequest.SignupRequest;
 import com.lgcms.auth.remote.member.dto.MemberResponse.SignupResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(
     name = "RemoteMemberService",
@@ -14,4 +16,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 public interface RemoteMemberService {
     @PostMapping("/signup")
     public ResponseEntity<SignupResponse> signup(@RequestBody SignupRequest request);
+
+    @DeleteMapping("/signout")
+    public ResponseEntity<Boolean> signout(@RequestParam Long memberId);
 }

--- a/src/main/java/com/lgcms/auth/repository/JtiRedisRepository.java
+++ b/src/main/java/com/lgcms/auth/repository/JtiRedisRepository.java
@@ -1,0 +1,26 @@
+package com.lgcms.auth.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+public class JtiRedisRepository {
+    private final RedisTemplate<String, String> redisTemplate;
+    private final String keyPrefix = "jti:";
+    private final String value = "revoked";
+    private @Value("${jwt.refresh_expired_time}") Long refreshExpiredTime;
+
+    public boolean addJti(String jti) {
+        redisTemplate.opsForValue().set(keyPrefix + jti, value, Duration.ofMillis(refreshExpiredTime));
+        return true;
+    }
+
+    public boolean isBlackList(String jti) {
+        return redisTemplate.opsForValue().get(keyPrefix + jti) != null;
+    }
+}

--- a/src/main/java/com/lgcms/auth/service/AuthService.java
+++ b/src/main/java/com/lgcms/auth/service/AuthService.java
@@ -70,4 +70,8 @@ public class AuthService {
         String refreshToken = jwtTokenProvider.createJwt(memberId, JwtType.REFRESH_TOKEN, currentTimeMillis, jti);
         return TokenResponse.toDto(accessToken, refreshToken);
     }
+
+    public boolean logout(String jti) {
+        return jtiRedisRepository.addJti(jti);
+    }
 }

--- a/src/main/java/com/lgcms/auth/service/AuthService.java
+++ b/src/main/java/com/lgcms/auth/service/AuthService.java
@@ -60,8 +60,9 @@ public class AuthService {
 
     private TokenResponse createTokens(String memberId) {
         long currentTimeMillis = System.currentTimeMillis();
-        String accessToken = jwtTokenProvider.createJwt(memberId, JwtType.ACCESS_TOKEN, currentTimeMillis);
-        String refreshToken = jwtTokenProvider.createJwt(memberId, JwtType.REFRESH_TOKEN, currentTimeMillis);
+        String jti = jwtTokenProvider.createJti();
+        String accessToken = jwtTokenProvider.createJwt(memberId, JwtType.ACCESS_TOKEN, currentTimeMillis, jti);
+        String refreshToken = jwtTokenProvider.createJwt(memberId, JwtType.REFRESH_TOKEN, currentTimeMillis, jti);
         return TokenResponse.toDto(accessToken, refreshToken);
     }
 }

--- a/src/main/java/com/lgcms/auth/service/AuthService.java
+++ b/src/main/java/com/lgcms/auth/service/AuthService.java
@@ -74,4 +74,10 @@ public class AuthService {
     public boolean logout(String jti) {
         return jtiRedisRepository.addJti(jti);
     }
+
+    public boolean signout(String jti, Long memberId) {
+        remoteMemberService.signout(memberId);
+        jtiRedisRepository.addJti(jti);
+        return true;
+    }
 }

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -5,6 +5,11 @@ spring:
         config:
           RemoteMemberService:
             url: http://localhost:8081
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      database: 0
 jwt:
   issuer: lgcms
   refresh_jwt_secret: helloworldshouldsecretkeysizemorebigger?moremoremoremorebiggerwhatsgoingoninthisplacerefresh

--- a/src/test/java/com/lgcms/auth/common/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/lgcms/auth/common/jwt/JwtTokenProviderTest.java
@@ -1,0 +1,35 @@
+package com.lgcms.auth.common.jwt;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@DisplayName("JwtTokenProvider로 ")
+class JwtTokenProviderTest {
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Test
+    @DisplayName("생성한 jwt의 jti를 추출할 수 있다")
+    void getJti() {
+        // given
+        String memberId = "1";
+        long currentTimeMillis = System.currentTimeMillis();
+        String jti = jwtTokenProvider.createJti();
+        String accessToken = jwtTokenProvider.createJwt(memberId, JwtType.ACCESS_TOKEN, currentTimeMillis, jti);
+        String refreshToken = jwtTokenProvider.createJwt(memberId, JwtType.REFRESH_TOKEN, currentTimeMillis, jti);
+
+        // when
+        String accessJti = jwtTokenProvider.getJti(accessToken, JwtType.ACCESS_TOKEN);
+        String refreshJti = jwtTokenProvider.getJti(refreshToken, JwtType.REFRESH_TOKEN);
+
+        // then
+        assertThat(accessJti).isEqualTo(refreshJti);
+    }
+}


### PR DESCRIPTION
## 작업 내용
    - jti 기반 리프레시 토큰 블랙리스트 적용
    - 로그아웃 시 토큰 블랙리스트
    - 회원탈퇴 API
## 회고, 느낀점
    - 구글 인증서버쪽의 회원 정보에 대한 제거는 현재 크게 필요하지 않아 붙이지는 않았습니다.